### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ A copy of the license is included in the root of the plugin’s directory. The f
 
 When contributing or extending the plugin, please follow the established file structure:
 
-* **[`wp-paradb/includes`](wp-paradb/includes)** - Core functionality shared between admin and public areas
-* **[`wp-paradb/admin`](wp-paradb/admin)** - All admin-specific functionality and interfaces  
-* **[`wp-paradb/public`](wp-paradb/public)** - All public-facing functionality and displays
+* **[`includes/`](includes/)** - Core functionality shared between admin and public areas
+* **[`admin/`](admin/)** - All admin-specific functionality and interfaces  
+* **[`public/`](public/)** - All public-facing functionality and displays
 
 ## 👥 Credits
 
@@ -69,9 +69,9 @@ This plugin is created with the organization and leadership of **Brian Chabot** 
 
 ### Contributing
 
-We welcome contributions!
+We welcome contributions from the community!
 
-If you’re interested in writing documentation or creating tutorials, please feel free to contribute at the [project repository](https://github.com/bchabot/wp-paradb).
+Whether you’re interested in writing documentation, creating tutorials, fixing bugs, or adding new features, please feel free to get involved at the [project repository](https://github.com/bchabot/wp-paradb).
 
 ### Project Updates
 


### PR DESCRIPTION
## Summary

This PR improves the README documentation with the following changes:

### Changes Made

1. **Fixed incorrect directory links** in the Plugin Structure section:
   - Changed `wp-paradb/includes` → `includes/`
   - Changed `wp-paradb/admin` → `admin/`
   - Changed `wp-paradb/public` → `public/`
   
   The previous links were incorrect as they referenced a nested path that doesn't exist in the repository structure.

2. **Expanded the Contributing section** with friendlier, more inclusive wording:
   - Changed "We welcome contributions!" → "We welcome contributions from the community!"
   - Expanded the invitation to include not just documentation and tutorials, but also bug fixes and new features
   - Changed "contribute at" → "get involved at" for a more welcoming tone

### Review Checklist

- [x] Links in Plugin Structure section now correctly point to existing directories
- [x] Contributing section is more welcoming and inclusive

@bchabot can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3d96d772ed7d40e08f4dfbffe0730a5b)